### PR TITLE
Update support links after RoboSats' announcement

### DIFF
--- a/robosats.md
+++ b/robosats.md
@@ -291,7 +291,7 @@ The RoboSats team realise this and have started work on a [federated model](http
 
 ### Written Guides
 
-Check out [Athena Alpha](https://www.athena-alpha.com/how-to-buy-bitcoins-using-robosats/) for their guide on how to buy bitcoins with RoboSats or their full reivew [here](https://www.athena-alpha.com/robosats-review/).
+Check out [Athena Alpha](https://www.athena-alpha.com/how-to-buy-bitcoins-using-robosats/) for their guide on how to buy bitcoins with RoboSats or their full review [here](https://www.athena-alpha.com/robosats-review/).
 
 ### Video Guides
 
@@ -319,8 +319,11 @@ Use RoboSats by any of the following methods:
 - [Your own client](#run-your-own-robosats-client)
 
 If you have any questions or feedback, get involved via these options:
-- [Telegram](https://t.me/robosats)
+- [SimpleX](https://simplex.chat/contact/#/?v=1-2&smp=smp%3A%2F%2F0YuTwO05YJWS8rkjn9eLJDjQhFKvIYd8d4xG8X1blIU%3D%40smp8.simplex.im%2FyEX_vdhWew_FkovCQC3mRYRWZB1j_cBq%23%2F%3Fv%3D1-2%26dh%3DMCowBQYDK2VuAyEAnrf9Jw3Ajdp4EQw71kqA64VgsIIzw8YNn68WjF09jFY%253D%26srv%3Dbeccx4yfxxbvyhqypaavemqurytl6hozr47wfc7uuecacjqdvwpw2xid.onion&data=%7B%22type%22%3A%22group%22%2C%22groupLinkId%22%3A%22hWnMVPnJl-KT3-virDk0JA%3D%3D%22%7D)
 - [Reddit](https://reddit.com/r/robosats)
+- [Matrix](https://matrix.to/#/#robosats:matrix.org)
+
+*Starting from June 12th, 2023, the Robosats Telegram group will no longer be active. More info [here](https://twitter.com/RoboSats/status/1668043842275229696?s=20)*.
 
 Remember - No RoboSats representative will ever contact you unannounced via any of these platforms. If someone does, they are almost certainly a scammer and should be blocked.
 


### PR DESCRIPTION
I came across an update from RoboSats on their official accounts stating that they are shifting their communication from Telegram to SimpleX/Nostr for general support and the existing Matrix dev chat. The announcement can be found on their Twitter/Nostr account, and [here](https://twitter.com/RoboSats/status/1668043842275229696?s=20) is a direct link to it. 

<img width="593" alt="Screenshot 2023-06-12 at 02 37 57" src="https://github.com/BitcoinQnA/Bitcoiner.Guide/assets/130449519/68739e2e-8995-46ac-9e0f-b0a8074ded7a">

With RoboSats gaining more popularity in the P2P market, I believe it's essential to update the guide as many individuals depend on Telegram for assistance. I have added SimpleX and Matrix and removed Telegram.