### PR TITLE
Fix broken link to bitcoin-only.com/meetups

### DIFF
--- a/privacy/get.md
+++ b/privacy/get.md
@@ -74,7 +74,7 @@ Given these risks it seems logical that step 1 of your Bitcoin privacy journey s
   
 - **Misc**
   - [Earn it](https://www.lopp.net/bitcoin-information/buying-earning.html#earning)
-  - [Buy in person at a meetup](https://bitcoin-only.com/#meetups)
+  - [Buy in person at a meetup](https://bitcoin-only.com/meetups)
   - [Mine it](https://diverter.hostyourown.tools/mining-for-the-streets/)
   
   


### PR DESCRIPTION
This is a fix for the page `https://bitcoiner.guide/privacy/get`.

There is a broken link for `Buy it in person at a meetup`.

This pull request changes that link:

from `https://bitcoin-only.com/#meetups`

to `https://bitcoin-only.com/meetups`