### PR TITLE
nokyconly: remove shutdown AgoraDesk on-ramp

### DIFF
--- a/nokyconly/index.md
+++ b/nokyconly/index.md
@@ -85,7 +85,6 @@ Thankfully there are some options out there to purchase Bitcoin via no KYC sourc
 * [**Bisq**](https://bisq.network)
 * [**RoboSats**](https://github.com/Reckless-Satoshi/robosats#bitcoin-mainnet)
 * [**Local Coin Swap**](https://localcoinswap.com/)
-* [**Agora Desk**](https://agoradesk.com)
 * [**Peach Bitcoin**](https://peachbitcoin.com/)
 
 


### PR DESCRIPTION
> AgoraDesk will be winding down
> The winding down process begins May 7th, 2024, and finishes after November 7th, 2024. Our [support](https://agoradesk.com/support) staff will be available for help throughout this period.
> 1. Effective immediately, all new signups and ad postings are disabled;
> 2. On May 14th, 2024, new trades will be disabled as well;
> 3. After November 7th, 2024, the website will be taken down. Please reclaim any funds from your arbitration bond wallet prior to that date, otherwise the funds may be considered abandoned/forfeited.
> 
> [Read more](https://agoradesk.com/blog/announcements/winding-down)